### PR TITLE
A possible setTxPower method fix

### DIFF
--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -42,7 +42,8 @@ uint32_t sd_ble_gatts_value_set(uint16_t handle, uint16_t offset, uint16_t* cons
     }                                           \
   } while (0)
 #else
-#define PRINT_ERROR(RET_CODE)
+#define APP_ERROR_CHECK(ERR_CODE)   null
+#define PRINT_ERROR(RET_CODE) // without this if NRF_52840_DEBUG is not set compiling will fail
 #endif
 
 #define APP_BLE_CONN_CFG_TAG             1

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -42,7 +42,7 @@ uint32_t sd_ble_gatts_value_set(uint16_t handle, uint16_t offset, uint16_t* cons
     }                                           \
   } while (0)
 #else
-#define APP_ERROR_CHECK(ERR_CODE)   null
+#define PRINT_ERROR(RET_CODE)
 #endif
 
 #define APP_BLE_CONN_CFG_TAG             1
@@ -77,7 +77,8 @@ nRF52840::nRF52840() :
   _remoteServiceDiscoveryIndex(0),
   _numRemoteCharacteristics(0),
   _remoteCharacteristicInfo(NULL),
-  _remoteRequestInProgress(false)
+  _remoteRequestInProgress(false),
+  _txPower(0)
 {
 #if defined(NRF5) || defined(NRF52_S140)
   this->_encKey = (ble_gap_enc_key_t*)&this->_bondData;
@@ -613,6 +614,10 @@ void nRF52840::poll() {
 
         this->_connectionHandle = bleEvt->evt.gap_evt.conn_handle;
         this->_txBufferCount = BLE_GATTC_WRITE_CMD_TX_QUEUE_SIZE_DEFAULT;
+
+      #if defined(NRF52_S140)
+        sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_CONN, this->_connectionHandle, this->_txPower);
+      #endif
 
         if (this->_eventListener) {
           this->_eventListener->BLEDeviceConnected(*this, bleEvt->evt.gap_evt.params.connected.peer_addr.addr);
@@ -1325,29 +1330,39 @@ bool nRF52840::unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& character
   return success;
 }
 
+bool isTxPowerValid(int txPower) {
+#if defined(NRF52840)
+  static const int8_t permittedTxValues[] = {
+    -40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8
+  };
+#else  
+  static const int8_t permittedTxValues[] = {
+     -40, -30, -20, -16, -12, -8, -4, 0, 4
+  };
+#endif
+
+  for(uint8_t i = 0; i < sizeof(permittedTxValues); i++) {
+    if (txPower == permittedTxValues[i]) {
+      return true;
+    }
+  }
+  
+  return false;
+}
+
 bool nRF52840::setTxPower(int txPower) {
-  if (txPower <= -40) {
-    txPower = -40;
-  } else if (txPower <= -30) {
-    txPower = -30;
-  } else if (txPower <= -20) {
-    txPower = -20;
-  } else if (txPower <= -16) {
-    txPower = -16;
-  } else if (txPower <= -12) {
-    txPower = -12;
-  } else if (txPower <= -8) {
-    txPower = -8;
-  } else if (txPower <= -4) {
-    txPower = -4;
-  } else if (txPower <= 0) {
-    txPower = 0;
-  } else {
-    txPower = 4;
+  if (! isTxPowerValid(txPower)) {
+    this->_txPower = 0;
+    return false;
   }
 
-//  return (sd_ble_gap_tx_power_set(txPower) == NRF_SUCCESS);
-  return (sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, _advHandle, 0) == NRF_SUCCESS);
+  this->_txPower = txPower;
+  
+  #if defined(NRF52_S140)
+    return sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, _advHandle, this->_txPower) == NRF_SUCCESS;
+  #else
+    return sd_ble_gap_tx_power_set(this->_txPower) == NRF_SUCCESS;
+  #endif
 }
 
 void nRF52840::faultHandler(uint32_t id, uint32_t pc, uint32_t info) {
@@ -1362,7 +1377,7 @@ void nRF52840::startAdvertising() {
 #endif
   uint32_t ret;
 
-  ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, _advHandle, 0);
+  ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, _advHandle, this->_txPower);
   PRINT_ERROR(ret);
   ret = sd_ble_gap_adv_start(_advHandle, APP_BLE_CONN_CFG_TAG);
   PRINT_ERROR(ret);


### PR DESCRIPTION
In the original code **setTxPower** doesn't do really something as it's always hard coded to **0**. I created this PR that should eventually fix that. 

Please bear in mind that I'm not a Nordic SDK user - I don't have any substantial knowledge of it (or very- very minimal knowledge so to speak). I studied the original code, browsed some of the Nordic SDK online documentation, examples and by doing some analogies I came up with this. 

I can't say that I did some valid tests for this besides compiling which works, and doing some tests using my phone and watching RSSI - but this is not a real test regarding range improvements. I did noticed some difference but I'm not really sure if it's the real thing actually.

Great work btw for bringing up NRF52840 into the scheme with this fork. Any plans on creating a PR on the sandeepmistry git repo?