### PR TITLE
A possible setTxPower method fix

### DIFF
--- a/examples/tx_power/tx_power.ino
+++ b/examples/tx_power/tx_power.ino
@@ -1,0 +1,51 @@
+// Copyright (c) Sandeep Mistry. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This work file is based on the arduino-ble-led example, adapted for PCA10059 and using setTxPower
+
+#include <Arduino.h>
+
+// LED pin
+#define LED_PIN   LED_BUILTIN
+
+#include <BLEPeripheral.h>
+BLEPeripheral blePeripheral = BLEPeripheral();
+BLEService ledService = BLEService("19b10000e8f2537e4f6cd104768a1214");
+BLECharCharacteristic switchCharacteristic = BLECharCharacteristic("19b10001e8f2537e4f6cd104768a1214", BLERead | BLEWrite);
+
+void setup() {
+  // set LED pins to output open drain mode
+  pinMode(LED_PIN, OUTPUT_OPEN_DRAIN);
+  digitalWrite(LED_PIN, LOW);
+
+  // set advertised local name and service UUID
+  blePeripheral.setLocalName("PCA10059");
+  blePeripheral.setDeviceName("Green LED");
+  blePeripheral.setAdvertisedServiceUuid(ledService.uuid());
+  // add service and characteristic
+  blePeripheral.addAttribute(ledService);
+  blePeripheral.addAttribute(switchCharacteristic);
+  //set tx power for both advertising and connected mode
+  blePeripheral.setTxPower(8);
+  // begin initialization
+  blePeripheral.begin();
+  
+  digitalWrite(LED_PIN, HIGH);
+}
+
+void loop() {
+  BLECentral central = blePeripheral.central();
+
+  if (central) {
+    while (central.connected()) {
+      // central still connected to peripheral
+      if (switchCharacteristic.written()) {
+        // central wrote new value to characteristic, update LED
+        if (switchCharacteristic.value()) {
+          digitalWrite(LED_PIN, LOW);
+        } else {
+          digitalWrite(LED_PIN, HIGH);
+        }
+      }
+    }
+  }
+}

--- a/examples/tx_power/tx_power.ino
+++ b/examples/tx_power/tx_power.ino
@@ -14,16 +14,16 @@ BLECharCharacteristic switchCharacteristic = BLECharCharacteristic("19b10001e8f2
 
 void blePeripheralConnectHandler(BLECentral& central) {
   // central connected event handler
-#if defined(NRF52_S140)  
-  blePeripheral.setConnectedTxPower(4);
-#endif
+// #if defined(NRF52_S140)  
+//   blePeripheral.setConnectedTxPower(4);
+// #endif
 }
 
 void blePeripheralDisconnectHandler(BLECentral& central) {
   // central disconnected event handler
-#if defined(NRF52_S140)  
-  blePeripheral.setAdvertisingTxPower(0);
-#endif
+// #if defined(NRF52_S140)  
+//   blePeripheral.setAdvertisingTxPower(0);
+// #endif
 }
 
 // central wrote new value to characteristics, update state
@@ -49,11 +49,10 @@ void setup() {
 
   // assign event handlers for led characteristic
   switchCharacteristic.setEventHandler(BLEWritten, ledCharacteristicWritten);
-  // begin initialization
-  blePeripheral.begin();
-  // must be called after begin()
   //set tx power for both advertising and connected mode
   blePeripheral.setTxPower(8);
+  // begin initialization
+  blePeripheral.begin();
   
   digitalWrite(LED_PIN, HIGH);
 }

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -69,7 +69,9 @@ class BLEDevice
 
     virtual void end() { }
 
-    virtual bool setTxPower(int /*txPower*/) { return false; }
+    virtual bool setTxPower(int8_t /*txPower*/) { return false; }
+    virtual boolean setAdvertisingTxPower(int8_t txPower) { return false; }
+    virtual boolean setConnectedTxPower(int8_t txPower) {return false; }
 
     virtual void startAdvertising() { }
     virtual void disconnect() { }

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -205,6 +205,7 @@ boolean  BLEPeripheral::setTxPower(int8_t txPower) {
   return this->_device->setTxPower(txPower);
 }
 
+#if defined(NRF52_S140)
 boolean setAdvertisingTxPower(int8_t txPower) {
   return this->_device->setAdvertisingTxPower(txPower);
 }
@@ -212,6 +213,7 @@ boolean setAdvertisingTxPower(int8_t txPower) {
 boolean setConnectedTxPower(int8_t txPower) {
   return this->_device->setConnectedTxPower(txPower);
 }
+#endif
 
 void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {
   this->_device->setBondStore(bondStore);

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -201,8 +201,16 @@ void BLEPeripheral::setConnectable(bool connectable) {
   this->_device->setConnectable(connectable);
 }
 
-bool  BLEPeripheral::setTxPower(int txPower) {
+boolean  BLEPeripheral::setTxPower(int8_t txPower) {
   return this->_device->setTxPower(txPower);
+}
+
+boolean setAdvertisingTxPower(int8_t txPower) {
+  return this->_device->setAdvertisingTxPower(txPower);
+}
+
+boolean setConnectedTxPower(int8_t txPower) {
+  return this->_device->setConnectedTxPower(txPower);
 }
 
 void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -206,11 +206,11 @@ boolean  BLEPeripheral::setTxPower(int8_t txPower) {
 }
 
 #if defined(NRF52_S140)
-boolean setAdvertisingTxPower(int8_t txPower) {
+boolean BLEPeripheral::setAdvertisingTxPower(int8_t txPower) {
   return this->_device->setAdvertisingTxPower(txPower);
 }
 
-boolean setConnectedTxPower(int8_t txPower) {
+boolean BLEPeripheral::setConnectedTxPower(int8_t txPower) {
   return this->_device->setConnectedTxPower(txPower);
 }
 #endif

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -201,11 +201,11 @@ void BLEPeripheral::setConnectable(bool connectable) {
   this->_device->setConnectable(connectable);
 }
 
-boolean  BLEPeripheral::setTxPower(int8_t txPower) {
+boolean BLEPeripheral::setTxPower(int8_t txPower) {
   return this->_device->setTxPower(txPower);
 }
 
-#if defined(NRF52_S140)
+#if defined(NRF52840)
 boolean BLEPeripheral::setAdvertisingTxPower(int8_t txPower) {
   return this->_device->setAdvertisingTxPower(txPower);
 }

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -78,7 +78,9 @@ class BLEPeripheral : public BLEDeviceEventListener,
     // connection intervals in 1.25 ms increments,
     // must be between  0x0006 (7.5 ms) and 0x0c80 (4 s), values outside of this range will be ignored
     void setConnectionInterval(unsigned short minimumConnectionInterval, unsigned short maximumConnectionInterval);
-    bool setTxPower(int txPower);
+    boolean setTxPower(int8_t txPower);
+    boolean setAdvertisingTxPower(int8_t txPower);
+    boolean setConnectedTxPower(int8_t txPower);
     void setConnectable(bool connectable);
     void setBondStore(BLEBondStore& bondStore);
 

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -79,8 +79,10 @@ class BLEPeripheral : public BLEDeviceEventListener,
     // must be between  0x0006 (7.5 ms) and 0x0c80 (4 s), values outside of this range will be ignored
     void setConnectionInterval(unsigned short minimumConnectionInterval, unsigned short maximumConnectionInterval);
     boolean setTxPower(int8_t txPower);
+#if defined(NRF52_S140)    
     boolean setAdvertisingTxPower(int8_t txPower);
     boolean setConnectedTxPower(int8_t txPower);
+#endif    
     void setConnectable(bool connectable);
     void setBondStore(BLEBondStore& bondStore);
 

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -79,7 +79,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     // must be between  0x0006 (7.5 ms) and 0x0c80 (4 s), values outside of this range will be ignored
     void setConnectionInterval(unsigned short minimumConnectionInterval, unsigned short maximumConnectionInterval);
     boolean setTxPower(int8_t txPower);
-#if defined(NRF52_S140)    
+#if defined(NRF52840)    
     boolean setAdvertisingTxPower(int8_t txPower);
     boolean setConnectedTxPower(int8_t txPower);
 #endif    

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1374,7 +1374,7 @@ boolean nRF52840::setTxPower(int8_t txPower) {
 }
 
 #if defined(NRF52_S140)
-// has effect when in advertising mode only
+// set tx power for advertising mode
 boolean nRF52840::setAdvertisingTxPower(int8_t txPower) {
   uint32_t ret;
   
@@ -1382,15 +1382,13 @@ boolean nRF52840::setAdvertisingTxPower(int8_t txPower) {
     return false;
   }
   
-  if (this->_advHandle) {
-    ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, this->_advHandle, txPower);
-    PRINT_ERROR(ret);
-  }
+  ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, this->_advHandle, txPower);
+  PRINT_ERROR(ret);
   
   return ret == NRF_SUCCESS;
 }
 
-// has effect only when connected
+// set tx power for when connected
 boolean nRF52840::setConnectedTxPower(int8_t txPower) {
   uint32_t ret;
   
@@ -1398,10 +1396,8 @@ boolean nRF52840::setConnectedTxPower(int8_t txPower) {
     return false;
   }
   
-  if (this->_connectionHandle) {
-    ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_CONN, this->_connectionHandle, txPower);
-    PRINT_ERROR(ret);
-  }
+  ret = sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_CONN, this->_connectionHandle, txPower);
+  PRINT_ERROR(ret);
   
   return ret == NRF_SUCCESS;
 }

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1361,7 +1361,7 @@ Valid values are depending on the MCU:
 */
 
 
-boolean nRF52840::setTxPower(int txPower) {
+boolean nRF52840::setTxPower(int8_t txPower) {
   uint32_t ret = NRF_SUCCESS;
   
   if (! isTxPowerValid(txPower)) {

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1361,7 +1361,6 @@ Valid values are depending on the MCU:
 */
 bool nRF52840::setTxPower(int txPower) {
   if (! isTxPowerValid(txPower)) {
-    this->_txPower = 0;
     return false;
   }
 
@@ -1372,6 +1371,8 @@ bool nRF52840::setTxPower(int txPower) {
   #if ! defined(NRF52_S140)
     return sd_ble_gap_tx_power_set(this->_txPower) == NRF_SUCCESS;
   #endif
+  
+  return true;
 }
 
 void nRF52840::faultHandler(uint32_t id, uint32_t pc, uint32_t info) {

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1351,6 +1351,14 @@ bool isTxPowerValid(int txPower) {
   return false;
 }
 
+/*
+Must be called before begin() method.
+
+Valid values are depending on the MCU:
+  NRF52840: -40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8
+  NRF51822: -30, -20, -16, -12, -8, -4, 0, 4
+  NRF52832: -40, -30, -20, -16, -12, -8, -4, 0, 4
+*/
 bool nRF52840::setTxPower(int txPower) {
   if (! isTxPowerValid(txPower)) {
     this->_txPower = 0;
@@ -1359,9 +1367,9 @@ bool nRF52840::setTxPower(int txPower) {
 
   this->_txPower = txPower;
   
-  #if defined(NRF52_S140)
-    return sd_ble_gap_tx_power_set(BLE_GAP_TX_POWER_ROLE_ADV, _advHandle, this->_txPower) == NRF_SUCCESS;
-  #else
+  // the sd_ble_gap_tx_power_set function signature changed in newer softdevices
+  // it allows setting tx power for advertising mode or connected mode and not for all modes at once as it was before
+  #if ! defined(NRF52_S140)
     return sd_ble_gap_tx_power_set(this->_txPower) == NRF_SUCCESS;
   #endif
 }

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1379,7 +1379,7 @@ boolean nRF52840::setTxPower(int txPower) {
 
 #if defined(NRF52_S140)
 // has effect when in advertising mode only
-boolean setAdvertisingTxPower(int8_t txPower) {
+boolean nRF52840::setAdvertisingTxPower(int8_t txPower) {
   uint32_t ret;
   
   if (! isTxPowerValid(txPower)) {
@@ -1395,7 +1395,7 @@ boolean setAdvertisingTxPower(int8_t txPower) {
 }
 
 // has effect only when connected
-boolean setConnectedTxPower(int8_t txPower) {
+boolean nRF52840::setConnectedTxPower(int8_t txPower) {
   uint32_t ret;
   
   if (! isTxPowerValid(txPower)) {

--- a/src/nRF52840.cpp
+++ b/src/nRF52840.cpp
@@ -1352,15 +1352,11 @@ bool isTxPowerValid(int txPower) {
 }
 
 /*
-Must be called after begin() method.
-
 Valid values are depending on the MCU:
   NRF52840: -40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8
   NRF51822: -30, -20, -16, -12, -8, -4, 0, 4
   NRF52832: -40, -30, -20, -16, -12, -8, -4, 0, 4
 */
-
-
 boolean nRF52840::setTxPower(int8_t txPower) {
   uint32_t ret = NRF_SUCCESS;
   

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -59,6 +59,8 @@ class nRF52840 : public BLEDevice
     virtual void end();
 
     virtual bool setTxPower(int txPower);
+    virtual boolean setConnectedTxPower(int8_t txPower);
+    virtual boolean setAdvertisingTxPower(int8_t txPower);
     virtual void startAdvertising();
     virtual void disconnect();
 

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -104,6 +104,7 @@ class nRF52840 : public BLEDevice
     unsigned char                     _numRemoteCharacteristics;
     struct remoteCharacteristicInfo*  _remoteCharacteristicInfo;
     bool                              _remoteRequestInProgress;
+    int8_t                            _txPower;
     static void faultHandler(uint32_t id, uint32_t pc, uint32_t info);
 };
 

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -82,7 +82,6 @@ class nRF52840 : public BLEDevice
 
   private:
 
-    int8_t _txPower;
     unsigned char                     _advData[BLE_GAP_ADV_SET_DATA_SIZE_MAX];
     unsigned char                     _scanRsp[BLE_GAP_ADV_SET_DATA_SIZE_MAX];
     unsigned char                     _advHandle;
@@ -105,6 +104,7 @@ class nRF52840 : public BLEDevice
     unsigned char                     _numRemoteCharacteristics;
     struct remoteCharacteristicInfo*  _remoteCharacteristicInfo;
     bool                              _remoteRequestInProgress;
+    int8_t                            _txPower;
     static void faultHandler(uint32_t id, uint32_t pc, uint32_t info);
 };
 

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -82,6 +82,7 @@ class nRF52840 : public BLEDevice
 
   private:
 
+    int8_t _txPower;
     unsigned char                     _advData[BLE_GAP_ADV_SET_DATA_SIZE_MAX];
     unsigned char                     _scanRsp[BLE_GAP_ADV_SET_DATA_SIZE_MAX];
     unsigned char                     _advHandle;

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -58,9 +58,11 @@ class nRF52840 : public BLEDevice
 
     virtual void end();
 
-    virtual bool setTxPower(int txPower);
+    virtual bool setTxPower(int8_t txPower);
+#if defined(NRF52_S140)      
     virtual boolean setConnectedTxPower(int8_t txPower);
     virtual boolean setAdvertisingTxPower(int8_t txPower);
+#endif    
     virtual void startAdvertising();
     virtual void disconnect();
 

--- a/src/nRF52840.h
+++ b/src/nRF52840.h
@@ -104,7 +104,6 @@ class nRF52840 : public BLEDevice
     unsigned char                     _numRemoteCharacteristics;
     struct remoteCharacteristicInfo*  _remoteCharacteristicInfo;
     bool                              _remoteRequestInProgress;
-    int8_t                            _txPower;
     static void faultHandler(uint32_t id, uint32_t pc, uint32_t info);
 };
 


### PR DESCRIPTION
In the original code the **setTxPower** method doesn't do really anything as it always uses a hard coded value of 0 behind the scenes. I created this PR that should eventually fix that.

Please bear in mind that I'm not a Nordic SDK user - I don't have any substantial knowledge of it (or very- very minimal knowledge so to speak). I studied the original code, browsed some of the Nordic SDK online documentation, examples and by doing some analogies I came up with this.

I can't say that I did some valid tests for this besides compiling which works, and doing some tests using my phone and watching RSSI - but this is not a real test regarding range improvements. I did noticed some difference but I'm not really sure if it's the real thing actually.

Great work btw for bringing up NRF52840 into the scheme with this fork. Any plans on creating a PR on the sandeepmistry git repo?